### PR TITLE
Fixed not being able access symbols that are being included from other files

### DIFF
--- a/server/src/pathUtils.ts
+++ b/server/src/pathUtils.ts
@@ -65,9 +65,9 @@ export function resolveIncludeUri(
 
     for (const dir of directoriesToSearch) {
         const fullPath = path.join(dir, includeFile);
-        const uri = URI.parse(fullPath).toString();
+        const uri = URI.file(fullPath).toString();
         if (symbolTables.has(uri)) {
-            return uri
+            return uri;
         }
     }
 


### PR DESCRIPTION
**Disclaimer: I know nothing about visual studio code extension development and this is all "vibe fixed", but can confirm that it seems to be working. I will leave it to you to decide if it is a good fix or not.**

Repro for this issue

```
; constants.inc
;...
PPU_CTRL   = $2000
;...
```

```
; main.s

.include "constants.inc"
;...
    lda #$00
    sta PPU_CTRL
;...

```

in that main.s you are unable to right click PPU_CTRL and use "go to definition"  "go to references" etc 